### PR TITLE
メディア付きツイートの一覧表示機能

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -12,6 +12,10 @@ class TweetsController < ApplicationController
       @tweets = current_user.tweets.reorder(favorite_count: 'DESC')
     elsif params[:quote]
       @tweets = current_user.tweets.where(is_quote_status: true)
+    elsif params[:video]
+      @tweets = current_user.tweets.joins(:tweet_videos)
+    elsif params[:image]
+      @tweets = current_user.tweets.joins(:tweet_images).distinct
     else
       @tweets = current_user.tweets
     end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -72,12 +72,14 @@ class Tweet < ApplicationRecord
                 media.video_info.variants.each do |variant|
                   if variant.content_type == "video/mp4"
                     isBreak = true
-                    _tweet.tweet_videos.new(tweet_video_url: variant.url)
+                    _tweet.tweet_videos.new(tweet_video_url: variant.url,
+                                            thumbnail: media.media_url_https)
                   end
                   break if isBreak
                 end
+              else
+                _tweet.tweet_images.new(tweet_image_url: media.media_url_https)
               end
-              _tweet.tweet_images.new(tweet_image_url: media.media_url_https)
             end
           end
           _tweet.save!

--- a/app/views/layouts/_sidenav.html.erb
+++ b/app/views/layouts/_sidenav.html.erb
@@ -14,7 +14,9 @@
   <% end %>
   <li><%= link_to "カテゴリー編集", categories_path, class: 'waves-effect' %></li>
   <li><%= link_to "いいね多い順", tweets_path(params: {sort: 1}), class: 'waves-effect' %></li>
-  <li><%= link_to "ユーザー一覧", post_users_path, class: 'waves-effect' %></li>
+  <li><%= link_to "投稿ユーザー別", post_users_path, class: 'waves-effect' %></li>
   <li><%= link_to "引用", tweets_path(params: {quote: 1}), class: 'waves-effect' %></li>
+  <li><%= link_to "動画", tweets_path(params: {video: 1}), class: 'waves-effect' %></li>
+  <li><%= link_to "画像", tweets_path(params: {image: 1}), class: 'waves-effect' %></li>
   <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'waves-effect' %></li>
 </ul>

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -6,7 +6,7 @@
         <span class="content">
           <p><%= text_url_to_link(h(tweet.text)).html_safe %></p>
           <% if tweet.tweet_videos.present? %>
-          <%= link_to image_tag(tweet.tweet_images.first.tweet_image_url, size: 50),
+          <%= link_to image_tag(tweet.tweet_videos.first.thumbnail, size: 50),
                       tweet.tweet_videos.first.tweet_video_url, data: {lity: "data-lity"} %>
           <% elsif (tweet.tweet_images.present?) %>
           <% tweet.tweet_images.each do |image| %>

--- a/db/migrate/20191002133628_add_thumbnail_to_tweet_video.rb
+++ b/db/migrate/20191002133628_add_thumbnail_to_tweet_video.rb
@@ -1,0 +1,5 @@
+class AddThumbnailToTweetVideo < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tweet_videos, :thumbnail, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_30_074820) do
+ActiveRecord::Schema.define(version: 2019_10_02_133628) do
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2019_09_30_074820) do
     t.integer "tweet_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "thumbnail"
     t.index ["tweet_id"], name: "index_tweet_videos_on_tweet_id"
   end
 


### PR DESCRIPTION
close #38
動画、画像付きツイートの一覧機能ができた。TweetVideoモデルにカラムを追加し動画、画像それぞれを抽出しやすいようにした。